### PR TITLE
return cache.put promise in chain

### DIFF
--- a/js/service-worker.js
+++ b/js/service-worker.js
@@ -115,7 +115,7 @@ self.addEventListener("fetch", function(event) {
                  available to caches.match(event.request) calls, when looking
                  for cached responses.
               */
-              cache.put(event.request, cacheCopy);
+              return cache.put(event.request, cacheCopy);
             })
             .then(function() {
               console.log('WORKER: fetch response stored in cache.', event.request.url);


### PR DESCRIPTION
After opening the cache, a put is executed and a log line is supposed to be written after the put is complete. `cache.put` returns a promise and returning it will wait the promise chain until that operation is complete and thus log the "response stored" message *after* the put is completed.